### PR TITLE
v0.2.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [3.0, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0]
+        ruby: [3.1, 3.0, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0]
     container: ruby:${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "imglab", "~> 0.1"
+gem "imglab", "~> 0.2"
 ```
 
 And then execute:
@@ -24,7 +24,7 @@ $ gem install imglab
 
 ## Ruby compatibility
 
-`imglab` has been successfully tested on the following Ruby versions: `3.0`, `2.7`, `2.6`, `2.5`, `2.4`, `2.3`, `2.2`, `2.1` and `2.0`.
+`imglab` has been successfully tested on the following Ruby versions: `3.1`, `3.0`, `2.7`, `2.6`, `2.5`, `2.4`, `2.3`, `2.2`, `2.1` and `2.0`.
 
 ## Generating URLs
 
@@ -34,17 +34,17 @@ The easiest way to generate a URL is to specify the `source_name`, `path` and re
 
 ```ruby
 Imglab.url("assets", "image.jpeg", width: 500, height: 600)
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600"
 
 Imglab.url("avatars", "user-01.jpeg", width: 300, height: 300, mode: :crop, crop: :face, format: :webp)
-"https://cdn.imglab.io/avatars/user-01.jpeg?width=300&height=300&mode=crop&crop=face&format=webp"
+"https://avatars.imglab-cdn.net/user-01.jpeg?width=300&height=300&mode=crop&crop=face&format=webp"
 ```
 
 If some specific settings are required for the source you can use an instance of `Imglab::Source` class instead of a `string` source name:
 
 ```ruby
 Imglab.url(Imglab::Source.new("assets"), "image.jpeg", width: 500, height: 600)
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600"
 ```
 
 ### Using secure image sources
@@ -55,7 +55,7 @@ For sources that require signed URLs you can specify `secure_key` and `secure_sa
 source = Imglab::Source.new("assets", secure_key: "assets-secure-key", secure_salt: "assets-secure-salt")
 
 Imglab.url(source, "image.jpeg", width: 500, height: 600)
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&signature=generated-signature"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&signature=generated-signature"
 ```
 
 `signature` query parameter will be automatically generated and attached to the returned URL.
@@ -68,7 +68,7 @@ In the case that HTTP schema is required instead of HTTPS you can set `https` at
 
 ```ruby
 Imglab.url(Imglab::Source.new("assets", https: false), "image.jpeg", width: 500, height: 600)
-"http://cdn.imglab.io/assets/image.jpeg?width=500&height=600"
+"http://assets.imglab-cdn.net/image.jpeg?width=500&height=600"
 ```
 
 > Note: HTTPS is the default and recommended way to generate URLs with imglab.
@@ -79,21 +79,21 @@ Any parameter from the imglab API can be used to generate URLs with `Imglab.url`
 
 ```ruby
 Imglab.url("assets", "image.jpeg", trim: "color", trim_color: "black")
-"https://cdn.imglab.io/assets/image.jpeg?trim=color&trim-color=black"
+"https://assets.imglab-cdn.net/image.jpeg?trim=color&trim-color=black"
 ```
 
 It is possible to use strings too:
 
 ```ruby
 Imglab.url("assets", "image.jpeg", "trim" => "color", "trim-color" => "black")
-"https://cdn.imglab.io/assets/image.jpeg?trim=color&trim-color=black"
+"https://assets.imglab-cdn.net/image.jpeg?trim=color&trim-color=black"
 ```
 
 And quoted symbols for Ruby version >= 2.2:
 
 ```ruby
 Imglab.url("assets", "image.jpeg", trim: "color", "trim-color": "black")
-"https://cdn.imglab.io/assets/image.jpeg?trim=color&trim-color=black"
+"https://assets.imglab-cdn.net/image.jpeg?trim=color&trim-color=black"
 ```
 
 ### Specifying color parameters
@@ -103,19 +103,19 @@ Some imglab parameters can receive a color as value. It is possible to specify t
 ```ruby
 # Specifying a RGB color as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: :contain, background_color: "255,0,0")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0"
 
 # Specifying a RGBA color as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: :contain, background_color: "255,0,0,128")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0%2C128"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0%2C128"
 
 # Specifying a named color as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: :contain, background_color: "red")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=red"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=red"
 
 # Specifying a hexadecimal color as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: :contain, background_color: "F00")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=F00"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=F00"
 ```
 
 You can additionally use `Imglab::Color` helpers to specify these color values:
@@ -126,15 +126,15 @@ include Imglab::Color
 
 # Using color helper for a RGB color
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: "contain", background_color: color(255, 0, 0))
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0"
 
 # Using color helper for a RGBA color
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: "contain", background_color: color(255, 0, 0, 128))
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0%2C128"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0%2C128"
 
 # Using color helper for a named color
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: "contain", background_color: color("red"))
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=red"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=red"
 ```
 
 > Note: specify hexadecimal color values using `Imglab::Color` helpers is not allowed. You can use strings instead.
@@ -146,15 +146,15 @@ Some imglab parameters can receive a position as value. It is possible to specif
 ```ruby
 # Specifying a horizontal and vertical position as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 500, mode: "crop", crop: "left,top")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=500&mode=crop&crop=left%2Ctop"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=500&mode=crop&crop=left%2Ctop"
 
 # Specifying a vertical and horizontal position as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 500, mode: "crop", crop: "top,left")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=500&mode=crop&crop=top%2Cleft"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=500&mode=crop&crop=top%2Cleft"
 
 # Specifying a position as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 500, mode: "crop", crop: "left")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=500&mode=crop&crop=left"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=500&mode=crop&crop=left"
 ```
 
 You can additionally use `Imglab::Position` helpers to specify these position values:
@@ -165,15 +165,15 @@ include Imglab::Position
 
 # Using position helper for a horizontal and vertical position
 Imglab.url("assets", "image.jpeg", width: 500, height: 500, mode: "crop", crop: position("left", "top"))
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=500&mode=crop&crop=left%2Ctop"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=500&mode=crop&crop=left%2Ctop"
 
 # Using position helper for a vertical and horizontal position
 Imglab.url("assets", "image.jpeg", width: 500, height: 500, mode: "crop", crop: position("top", "left"))
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=500&mode=crop&crop=top%2Cleft"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=500&mode=crop&crop=top%2Cleft"
 
 # Using position helper for a position
 Imglab.url("assets", "image.jpeg", width: 500, height: 500, mode: "crop", crop: position("left"))
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=500&mode=crop&crop=left"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=500&mode=crop&crop=left"
 ```
 
 ### Specifying URL parameters
@@ -182,14 +182,14 @@ Some imglab parameters can receive URLs as values. It is possible to specify the
 
 ```ruby
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, watermark: "logo.svg")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&watermark=logo.svg"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&watermark=logo.svg"
 ```
 
 And even use parameters if required:
 
 ```ruby
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, watermark: "logo.svg?width=100&format=png")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&watermark=logo.svg%3Fwidth%3D100%26format%3Dpng"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&watermark=logo.svg%3Fwidth%3D100%26format%3Dpng"
 ```
 
 Additionally you can use nested `Imglab.url` calls to specify these URL values:
@@ -202,7 +202,7 @@ Imglab.url(
   height: 600,
   watermark: Imglab.url("assets", "logo.svg", width: 100, format: "png")
 )
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&watermark=https%3A%2F%2Fcdn.imglab.io%2Fassets%2Flogo.svg%3Fwidth%3D100%26format%3Dpng"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&watermark=https%3A%2F%2Fassets.imglab-cdn.net%2Flogo.svg%3Fwidth%3D100%26format%3Dpng"
 ```
 
 If the resource is located in a different source we can specify it using `Imglab.url`:
@@ -215,7 +215,7 @@ Imglab.url(
   height: 600,
   watermark: Imglab.url("marketing", "logo.svg", width: 100, format: "png")
 )
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&watermark=https%3A%2F%2Fcdn.imglab.io%2Fmarketing%2Flogo.svg%3Fwidth%3D100%26format%3Dpng"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&watermark=https%3A%2F%2Fmarketing.imglab-cdn.net%2Flogo.svg%3Fwidth%3D100%26format%3Dpng"
 ```
 
 Using secure sources for URLs parameter values is possible too:
@@ -239,50 +239,50 @@ Imglab.url(
 For on-premises imglab server is possible to define custom sources pointing to your server location.
 
 * `:https` - a `boolean` value specifying if the source should use https or not (default: `true`)
-* `:host` - a `string` specifying the host where the imglab server is located. (default: `cdn.imglab.io`)
+* `:host` - a `string` specifying the host where the imglab server is located. (default: `imglab-cdn.net`)
 * `:port` - a `integer` specifying a port where the imglab server is located.
-* `:subdomains` - a `boolean` value specifying if the source should be specified using subdomains instead of using the path. (default: `false`)
+* `:subdomains` - a `boolean` value specifying if the source should be specified using subdomains instead of using the path. (default: `true`)
 
-If we have our on-premises imglab server at `http://imglab.mycompany.com:8080` with a source named `web-images` we can use the following source settings to access a `logo.png` image:
+If we have our on-premises imglab server at `http://my-company.com:8080` with a source named `images` we can use the following source settings to access a `logo.png` image:
 
 ```ruby
-source = Imglab::Source.new("web-images", https: false, host: "imglab.mycompany.com", port: 8080)
+source = Imglab::Source.new("images", https: false, host: "my-company.com", port: 8080)
 
 Imglab.url(source, "logo.png", width: 300, height: 300, format: "png")
-"http://imglab.mycompany.com:8080/web-images/logo.png?width=300&height=300&format=png"
+"http://images.my-company.com:8080/logo.png?width=300&height=300&format=png"
 ```
 
 It is possible to use secure sources too:
 
 ```ruby
 source = Imglab::Source.new(
-  "web-images",
+  "images",
   https: false,
-  host: "imglab.mycompany.com",
+  host: "my-company.com",
   port: 8080,
-  secure_key: "web-images-secure-key",
-  secure_salt: "web-images-secure-salt"
+  secure_key: "images-secure-key",
+  secure_salt: "images-secure-salt"
 )
 
 Imglab.url(source, "logo.png", width: 300, height: 300, format: "png")
-"http://imglab.mycompany.com:8080/web-images/logo.png?width=300&height=300&format=png&signature=generated-signature"
+"http://images.my-company.com:8080/logo.png?width=300&height=300&format=png&signature=generated-signature"
 ```
 
-### Using sudomains sources
+### Using sources with disabled subdomains
 
-In the case that your on-premises imglab server is configured to use source names as subdomains you can set `subdomains` attribute to `true` to generate URLs using subdomains:
+In the case that your on-premises imglab server is configured to use source names as paths instead of subdomains you can set `subdomains` attribute to `false`:
 
 ```ruby
 source = Imglab::Source.new(
-  "web-images",
+  "images",
   https: false,
-  host: "imglab.mycompany.com",
+  host: "my-company.com",
   port: 8080,
-  subdomains: true
+  subdomains: false
 )
 
-Imglab.url(source, "marketing/logo.png", width: 300, height: 300, format: "png")
-"http://web-images.imglab.mycompany.com:8080/marketing/logo.png?width=300&height=300&format=png"
+Imglab.url(source, "logo.png", width: 300, height: 300, format: "png")
+"http://my-company.com:8080/images/logo.png?width=300&height=300&format=png"
 ```
 
 ## License

--- a/lib/imglab.rb
+++ b/lib/imglab.rb
@@ -17,9 +17,9 @@ module Imglab
   # @raise [ArgumentError] when the source name or source parameter has a not expected type.
   #
   # @example Creating a URL specifying source name as string
-  #   Imglab.url("assets", "example.jpeg", width: 500, height: 600) #=> "https://cdn.imglab.io/assets/example.jpeg?width=500&height=600"
+  #   Imglab.url("assets", "example.jpeg", width: 500, height: 600) #=> "https://assets.imglab-cdn.net/example.jpeg?width=500&height=600"
   # @example Creating a URL specifying a Imglab::Source
-  #   Imglab.url(Imglab::Source.new("assets"), "example.jpeg", width: 500, height: 600) #=> "https://cdn.imglab.io/assets/example.jpeg?width=500&height=600"
+  #   Imglab.url(Imglab::Source.new("assets"), "example.jpeg", width: 500, height: 600) #=> "https://assets.imglab-cdn.net/example.jpeg?width=500&height=600"
   def self.url(source_name_or_source, path, params = {})
     case source_name_or_source
     when String
@@ -67,7 +67,7 @@ module Imglab
   def self.encode_params(source, path, params)
     return encode_empty_params(source, path) if params.empty?
 
-    if source.secure?
+    if source.is_secure?
       signature = Signature.generate(source, path, URI.encode_www_form(params))
 
       URI.encode_www_form(params.merge(signature: signature))
@@ -77,7 +77,7 @@ module Imglab
   end
 
   def self.encode_empty_params(source, path)
-    if source.secure?
+    if source.is_secure?
       signature = Signature.generate(source, path)
 
       URI.encode_www_form(signature: signature)

--- a/lib/imglab/source.rb
+++ b/lib/imglab/source.rb
@@ -1,7 +1,7 @@
 class Imglab::Source
   DEFAULT_HTTPS = true
-  DEFAULT_HOST = "cdn.imglab.io"
-  DEFAULT_SUBDOMAINS = false
+  DEFAULT_HOST = "imglab-cdn.net"
+  DEFAULT_SUBDOMAINS = true
 
   attr_reader :name, :https, :port, :secure_key, :secure_salt, :subdomains
 
@@ -13,7 +13,7 @@ class Imglab::Source
   # @param port [Integer] the port where the imglab server is located, only for imglab on-premises.
   # @param secure_key [String] the source secure key.
   # @param secure_salt [String] the source secure salt.
-  # @param subdomains [Boolean] specify if the source should use subdomains to build the host name, only for imglab on-premises.
+  # @param subdomains [Boolean] specify if the source should use subdomains instead of paths to build the host name, only for imglab on-premises.
   # @return [Imglab::Source] with the specified options.
   def initialize(name, host: DEFAULT_HOST, https: DEFAULT_HTTPS, port: nil, secure_key: nil, secure_salt: nil, subdomains: DEFAULT_SUBDOMAINS)
     @name = name
@@ -50,7 +50,7 @@ class Imglab::Source
   # Returns if the source is secure or not.
   #
   # @return [Boolean]
-  def secure?
+  def is_secure?
     @secure_key && @secure_salt
   end
 

--- a/lib/imglab/version.rb
+++ b/lib/imglab/version.rb
@@ -1,3 +1,3 @@
 module Imglab
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/test/imglab/source_test.rb
+++ b/test/imglab/source_test.rb
@@ -6,7 +6,7 @@ describe Imglab::Source do
       source = Imglab::Source.new("assets")
 
       assert_equal source.name, "assets"
-      assert_equal source.host, Imglab::Source::DEFAULT_HOST
+      assert_equal source.host, "assets.#{Imglab::Source::DEFAULT_HOST}"
       assert_equal source.https, Imglab::Source::DEFAULT_HTTPS
       assert_nil source.port, nil
       assert_nil source.secure_key, nil
@@ -15,12 +15,12 @@ describe Imglab::Source do
     end
 
     it "returns source instance expected optional values" do
-      assert_equal Imglab::Source.new("assets", host: "imglab.net").host, "imglab.net"
+      assert_equal Imglab::Source.new("assets", host: "imglab.net").host, "assets.imglab.net"
       assert_equal Imglab::Source.new("assets", https: false).https, false
       assert_equal Imglab::Source.new("assets", port: 8080).port, 8080
       assert_equal Imglab::Source.new("assets", secure_key: "secure-key").secure_key, "secure-key"
       assert_equal Imglab::Source.new("assets", secure_salt: "secure-salt").secure_salt, "secure-salt"
-      assert_equal Imglab::Source.new("assets", subdomains: true).subdomains, true
+      assert_equal Imglab::Source.new("assets", subdomains: false).subdomains, false
     end
   end
 
@@ -34,18 +34,18 @@ describe Imglab::Source do
 
   describe "#host" do
     it "returns correct host" do
-      assert_equal Imglab::Source.new("assets").host, "cdn.imglab.io"
-      assert_equal Imglab::Source.new("assets", subdomains: false).host, "cdn.imglab.io"
+      assert_equal Imglab::Source.new("assets").host, "assets.imglab-cdn.net"
+      assert_equal Imglab::Source.new("assets", subdomains: false).host, "imglab-cdn.net"
       assert_equal Imglab::Source.new("assets", subdomains: false, host: "imglab.net").host, "imglab.net"
-      assert_equal Imglab::Source.new("assets", subdomains: true).host, "assets.cdn.imglab.io"
+      assert_equal Imglab::Source.new("assets", subdomains: true).host, "assets.imglab-cdn.net"
       assert_equal Imglab::Source.new("assets", subdomains: true, host: "imglab.net").host, "assets.imglab.net"
     end
   end
 
   describe "#path" do
     it "returns correct path" do
-      assert_equal Imglab::Source.new("assets").path("example.jpeg"), "assets/example.jpeg"
-      assert_equal Imglab::Source.new("assets").path("subfolder/example.jpeg"), "assets/subfolder/example.jpeg"
+      assert_equal Imglab::Source.new("assets").path("example.jpeg"), "example.jpeg"
+      assert_equal Imglab::Source.new("assets").path("subfolder/example.jpeg"), "subfolder/example.jpeg"
       assert_equal Imglab::Source.new("assets", subdomains: false).path("example.jpeg"), "assets/example.jpeg"
       assert_equal Imglab::Source.new("assets", subdomains: false).path("subfolder/example.jpeg"), "assets/subfolder/example.jpeg"
       assert_equal Imglab::Source.new("assets", subdomains: true).path("example.jpeg"), "example.jpeg"
@@ -53,11 +53,12 @@ describe Imglab::Source do
     end
   end
 
-  describe "#secure?" do
+  describe "#is_secure?" do
     it "returns if source is secure or not" do
-      refute Imglab::Source.new("assets").secure?
-      refute Imglab::Source.new("assets", secure_key: "secure-key").secure?
-      assert Imglab::Source.new("assets", secure_key: "secure-key", secure_salt: "secure_salt").secure?
+      refute Imglab::Source.new("assets").is_secure?
+      refute Imglab::Source.new("assets", secure_key: "secure-key").is_secure?
+      refute Imglab::Source.new("assets", secure_salt: "secure-salt").is_secure?
+      assert Imglab::Source.new("assets", secure_key: "secure-key", secure_salt: "secure_salt").is_secure?
     end
   end
 end

--- a/test/imglab_test.rb
+++ b/test/imglab_test.rb
@@ -13,19 +13,19 @@ describe Imglab do
     it "returns url without params" do
       url = Imglab.url("assets", "example.jpeg")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg"
     end
 
     it "returns url with params" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with params using string path" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, watermark: "example.svg", format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=example.svg&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=example.svg&format=png"
     end
 
     it "returns url with params using string path with inline params" do
@@ -37,43 +37,43 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=example.svg%3Fwidth%3D100%26format%3Dpng&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=example.svg%3Fwidth%3D100%26format%3Dpng&format=png"
     end
 
     it "returns url with params using rgb color" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, background_color: color(255, 128, 122))
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&background-color=255%2C128%2C122"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&background-color=255%2C128%2C122"
     end
 
     it "returns url with params using rgba color" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, background_color: color(255, 128, 122, 128))
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&background-color=255%2C128%2C122%2C128"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&background-color=255%2C128%2C122%2C128"
     end
 
     it "returns url with params using named color" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, background_color: color("blue"))
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&background-color=blue"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&background-color=blue"
     end
 
     it "returns url with params using horizontal and vertical position" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, mode: "crop", crop: position("left", "bottom"))
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&mode=crop&crop=left%2Cbottom"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&mode=crop&crop=left%2Cbottom"
     end
 
     it "returns url with params using vertical and horizontal position" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, mode: "crop", crop: position("bottom", "left"))
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&mode=crop&crop=bottom%2Cleft"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&mode=crop&crop=bottom%2Cleft"
     end
 
     it "returns url with params using position" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, mode: "crop", crop: position("left"))
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&mode=crop&crop=left"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&mode=crop&crop=left"
     end
 
     it "returns url with params using url method with source" do
@@ -89,7 +89,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fcdn.imglab.io%2Fassets%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fassets.imglab-cdn.net%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
     end
 
     it "returns url with params using url method with source name" do
@@ -103,91 +103,91 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fcdn.imglab.io%2Fassets%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fassets.imglab-cdn.net%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
     end
 
     it "returns url with params using symbols with underscores" do
       url = Imglab.url("assets", "example.jpeg", trim: "color", trim_color: "orange")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?trim=color&trim-color=orange"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange"
     end
 
     it "returns url with params using symbols with hyphens" do
       url = Imglab.url("assets", "example.jpeg", :"trim" => "color", :"trim-color" => "orange")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?trim=color&trim-color=orange"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange"
     end
 
     it "returns url with path starting with slash" do
       url = Imglab.url("assets", "/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path starting with slash using reserved characters" do
       url = Imglab.url("assets", "/example image%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path starting and ending with slash" do
       url = Imglab.url("assets", "/example.jpeg/", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path starting and ending with slash using reserved characters" do
       url = Imglab.url("assets", "/example image%2C01%2C02.jpeg/", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with subfolder path starting with slash" do
       url = Imglab.url("assets", "/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/subfolder/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/subfolder/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with subfolder path starting with slash using reserved characters" do
       url = Imglab.url("assets", "/subfolder images/example image%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with subfolder path starting and ending with slash" do
       url = Imglab.url("assets", "/subfolder/example.jpeg/", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/subfolder/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/subfolder/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with subfolder path starting and ending with slash using reserved characters" do
       url = Imglab.url("assets", "/subfolder images/example image%2C01%2C02.jpeg/", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path using a http url" do
       url = Imglab.url("assets", "http://assets.com/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path using a http url with reserved characters" do
       url = Imglab.url("assets", "http://assets.com/subfolder/example%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path using a https url" do
       url = Imglab.url("assets", "https://assets.com/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path using a https url with reserved characters" do
       url = Imglab.url("assets", "https://assets.com/subfolder/example%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
   end
 
@@ -195,19 +195,19 @@ describe Imglab do
     it "returns url without params" do
       url = Imglab.url(Imglab::Source.new("assets"), "example.jpeg")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg"
     end
 
     it "returns url with params" do
       url = Imglab.url(Imglab::Source.new("assets"), "example.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with params using string path" do
       url = Imglab.url(Imglab::Source.new("assets"), "example.jpeg", width: 200, height: 300, watermark: "example.svg", format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=example.svg&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=example.svg&format=png"
     end
 
     it "returns url with params using string path with inline params" do
@@ -221,7 +221,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=example.svg%3Fwidth%3D100%26format%3Dpng&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=example.svg%3Fwidth%3D100%26format%3Dpng&format=png"
     end
 
     it "returns url with params using url with source" do
@@ -237,7 +237,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fcdn.imglab.io%2Fassets%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fassets.imglab-cdn.net%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
     end
 
     it "returns url with params using url method with source name" do
@@ -253,35 +253,35 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fcdn.imglab.io%2Fassets%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fassets.imglab-cdn.net%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
     end
 
     it "returns url with params using symbols with underscores" do
       url = Imglab.url(Imglab::Source.new("assets"), "example.jpeg", trim: "color", trim_color: "orange")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?trim=color&trim-color=orange"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange"
     end
 
     it "returns url with params using atoms with hyphens" do
       url = Imglab.url(Imglab::Source.new("assets"), "example.jpeg", :"trim" => "color", :"trim-color" => "orange")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?trim=color&trim-color=orange"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange"
     end
 
-    it "returns url with subdomains" do
+    it "returns url with disabled subdomains" do
       url =
         Imglab.url(
-          Imglab::Source.new("assets", subdomains: true),
+          Imglab::Source.new("assets", subdomains: false),
           "example.jpeg",
           width: 200,
           height: 300,
           format: "png"
         )
 
-      assert_equal url, "https://assets.cdn.imglab.io/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://imglab-cdn.net/assets/example.jpeg?width=200&height=300&format=png"
     end
 
-    it "returns url with http" do
+    it "returns url with disabled https" do
       url =
         Imglab.url(
           Imglab::Source.new("assets", https: false),
@@ -291,7 +291,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "http://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "http://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with host" do
@@ -304,7 +304,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://imglab.net/assets/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab.net/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with port" do
@@ -317,92 +317,92 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io:8080/assets/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net:8080/example.jpeg?width=200&height=300&format=png"
     end
 
-    it "returns url with subdomains, http, host and port" do
+    it "returns url with disabled subdomains, disabled https, host and port" do
       url =
         Imglab.url(
-          Imglab::Source.new("assets", subdomains: true, https: false, host: "imglab.net", port: 8080),
+          Imglab::Source.new("assets", subdomains: false, https: false, host: "imglab.net", port: 8080),
           "example.jpeg",
           width: 200,
           height: 300,
           format: "png"
         )
 
-      assert_equal url, "http://assets.imglab.net:8080/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "http://imglab.net:8080/assets/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path starting with slash" do
       url = Imglab.url(Imglab::Source.new("assets"), "/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path starting with slash using reserved characters" do
       url = Imglab.url(Imglab::Source.new("assets"), "/example image%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path starting and ending with slash" do
       url = Imglab.url(Imglab::Source.new("assets"), "/example.jpeg/", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path starting and ending with slash using reserved characters" do
       url = Imglab.url(Imglab::Source.new("assets"), "/example image%2C01%2C02.jpeg/", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with subfolder path starting with slash" do
       url = Imglab.url(Imglab::Source.new("assets"), "/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/subfolder/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/subfolder/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with subfolder path starting with slash using reserved characters" do
       url = Imglab.url(Imglab::Source.new("assets"), "/subfolder images/example image%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with subfolder path starting and ending with slash" do
       url = Imglab.url(Imglab::Source.new("assets"), "/subfolder/example.jpeg/", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/subfolder/example.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/subfolder/example.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with subfolder path starting and ending with slash using reserved characters" do
       url = Imglab.url(Imglab::Source.new("assets"), "/subfolder images/example image%2C01%2C02.jpeg/", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path using a http url" do
       url = Imglab.url(Imglab::Source.new("assets"), "http://assets.com/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path using a http url with reserved characters" do
       url = Imglab.url(Imglab::Source.new("assets"), "http://assets.com/subfolder/example%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path using a https url" do
       url = Imglab.url(Imglab::Source.new("assets"), "https://assets.com/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
     end
 
     it "returns url with path using a https url with reserved characters" do
       url = Imglab.url(Imglab::Source.new("assets"), "https://assets.com/subfolder/example%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "https://cdn.imglab.io/assets/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert_equal url, "https://assets.imglab-cdn.net/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
   end
 
@@ -414,7 +414,7 @@ describe Imglab do
           "example.jpeg"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?signature=aRgmnJ-7b2A0QLxXpR3cqrHVYmCfpRCOglL-nsp7SdQ"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?signature=aRgmnJ-7b2A0QLxXpR3cqrHVYmCfpRCOglL-nsp7SdQ"
     end
 
     it "returns url with params" do
@@ -427,7 +427,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
     it "returns url with params using string path" do
@@ -441,7 +441,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=example.svg&format=png&signature=xrwElVGVPyOrcTCNFnZiAa-tzkUp1ISrjnvEShSVsAg"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=example.svg&format=png&signature=xrwElVGVPyOrcTCNFnZiAa-tzkUp1ISrjnvEShSVsAg"
     end
 
     it "returns url with params using string path with inline params" do
@@ -455,7 +455,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=example.svg%3Fwidth%3D100%26format%3Dpng&format=png&signature=0yhBOktmTTVC-ANSxMuGK_LakyjCOlnGTSN3I13B188"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=example.svg%3Fwidth%3D100%26format%3Dpng&format=png&signature=0yhBOktmTTVC-ANSxMuGK_LakyjCOlnGTSN3I13B188"
     end
 
     it "returns url with params using url method with source" do
@@ -471,7 +471,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fcdn.imglab.io%2Fassets%2Fexample.svg%3Fwidth%3D100%26format%3Dpng%26signature%3DiKKUBWG4kZBv6CVxwaWGPpHd9LLTfuj9CBWamNYtWaI&format=png&signature=5__R2eDq59DYQnj64dyW3VlY-earzP6uyi624Q0Q4kU"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fassets.imglab-cdn.net%2Fexample.svg%3Fwidth%3D100%26format%3Dpng%26signature%3DiKKUBWG4kZBv6CVxwaWGPpHd9LLTfuj9CBWamNYtWaI&format=png&signature=ZMT8l8i9hKs4aYiIUXpGcMSzOGHS8xjUlQeTrvE8ESA"
     end
 
     it "returns url with params using url method with source name" do
@@ -487,7 +487,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fcdn.imglab.io%2Ffixtures%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png&signature=DiMzjeskcahfac0Xsy4QNj6qoU3dvKgOuFbHT7E4usU"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Ffixtures.imglab-cdn.net%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png&signature=6BowGGEXe9wUmGa4xkhoscfPkqrLGumkIglhPQEkNuo"
     end
 
     it "returns url with params using symbols with underscores" do
@@ -499,7 +499,7 @@ describe Imglab do
           trim_color: "orange"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?trim=color&trim-color=orange&signature=cfYzBKvaWJhg_4ArtL5IafGYU6FEgRb_5ZADIgvviWw"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange&signature=cfYzBKvaWJhg_4ArtL5IafGYU6FEgRb_5ZADIgvviWw"
     end
 
     it "returns url with params using symbols with hyphens" do
@@ -511,23 +511,23 @@ describe Imglab do
           :"trim-color" => "orange"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?trim=color&trim-color=orange&signature=cfYzBKvaWJhg_4ArtL5IafGYU6FEgRb_5ZADIgvviWw"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange&signature=cfYzBKvaWJhg_4ArtL5IafGYU6FEgRb_5ZADIgvviWw"
     end
 
-    it "returns url with subdomains" do
+    it "returns url with disabled subdomains" do
       url =
         Imglab.url(
-          Imglab::Source.new("assets", secure_key: @secure_key, secure_salt: @secure_salt, subdomains: true),
+          Imglab::Source.new("assets", secure_key: @secure_key, secure_salt: @secure_salt, subdomains: false),
           "example.jpeg",
           width: 200,
           height: 300,
           format: "png"
         )
 
-      assert_equal url, "https://assets.cdn.imglab.io/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert_equal url, "https://imglab-cdn.net/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
-    it "returns url with http" do
+    it "returns url with disabled https" do
       url =
         Imglab.url(
           Imglab::Source.new("assets", secure_key: @secure_key, secure_salt: @secure_salt, https: false),
@@ -537,7 +537,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "http://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert_equal url, "http://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
     it "returns url with host" do
@@ -550,7 +550,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://imglab.net/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert_equal url, "https://assets.imglab.net/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
     it "returns url with port" do
@@ -563,16 +563,16 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io:8080/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert_equal url, "https://assets.imglab-cdn.net:8080/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
-    it "returns url with subdomains, http, host and port" do
+    it "returns url with disabled subdomains, disabled https, host and port" do
       source =
         Imglab::Source.new(
           "assets",
           secure_key: @secure_key,
           secure_salt: @secure_salt,
-          subdomains: true,
+          subdomains: false,
           https: false,
           host: "imglab.net",
           port: 8080
@@ -580,7 +580,7 @@ describe Imglab do
 
       url = Imglab.url(source, "example.jpeg", width: 200, height: 300, format: "png")
 
-      assert_equal url, "http://assets.imglab.net:8080/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert_equal url, "http://imglab.net:8080/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
     it "returns url with path starting with slash" do
@@ -593,7 +593,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
     it "returns url with path starting with slash using reserved characters" do
@@ -606,7 +606,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=yZcUhTCB9VB3qzjyIJCCX_pfJ76Gb6kHe7KwusAPl-w"
+      assert_equal url, "https://assets.imglab-cdn.net/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=yZcUhTCB9VB3qzjyIJCCX_pfJ76Gb6kHe7KwusAPl-w"
     end
 
     it "returns url with path starting and ending with slash" do
@@ -619,7 +619,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert_equal url, "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
     it "returns url with path starting and ending with slash using reserved characters" do
@@ -632,7 +632,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=yZcUhTCB9VB3qzjyIJCCX_pfJ76Gb6kHe7KwusAPl-w"
+      assert_equal url, "https://assets.imglab-cdn.net/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=yZcUhTCB9VB3qzjyIJCCX_pfJ76Gb6kHe7KwusAPl-w"
     end
 
     it "returns url with subfolder path starting with slash" do
@@ -645,7 +645,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/subfolder/example.jpeg?width=200&height=300&format=png&signature=3jydAIXhF8Nn_LXKhog2flf7FsACzISi_sXCKmASkOs"
+      assert_equal url, "https://assets.imglab-cdn.net/subfolder/example.jpeg?width=200&height=300&format=png&signature=3jydAIXhF8Nn_LXKhog2flf7FsACzISi_sXCKmASkOs"
     end
 
     it "returns url with subfolder path starting with slash using reserved characters" do
@@ -658,7 +658,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=2oAmYelI7UEnvqSSPCfUA25TmS7na1FRVTaxfe5ADyY"
+      assert_equal url, "https://assets.imglab-cdn.net/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=2oAmYelI7UEnvqSSPCfUA25TmS7na1FRVTaxfe5ADyY"
     end
 
     it "returns url with subfolder path starting and ending with slash" do
@@ -671,7 +671,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/subfolder/example.jpeg?width=200&height=300&format=png&signature=3jydAIXhF8Nn_LXKhog2flf7FsACzISi_sXCKmASkOs"
+      assert_equal url, "https://assets.imglab-cdn.net/subfolder/example.jpeg?width=200&height=300&format=png&signature=3jydAIXhF8Nn_LXKhog2flf7FsACzISi_sXCKmASkOs"
     end
 
     it "returns url with subfolder path starting and ending with slash using reserved characters" do
@@ -684,7 +684,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=2oAmYelI7UEnvqSSPCfUA25TmS7na1FRVTaxfe5ADyY"
+      assert_equal url, "https://assets.imglab-cdn.net/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=2oAmYelI7UEnvqSSPCfUA25TmS7na1FRVTaxfe5ADyY"
     end
 
     it "returns url with path using a http url" do
@@ -697,7 +697,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png&signature=MuzfKbHDJY6lzeFQGRcsCS8DzxgL4nCpIowOMFLR1kA"
+      assert_equal url, "https://assets.imglab-cdn.net/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png&signature=MuzfKbHDJY6lzeFQGRcsCS8DzxgL4nCpIowOMFLR1kA"
     end
 
     it "returns url with path using a http url with reserved characters" do
@@ -710,7 +710,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png&signature=78e-ysfcy3d0e0rj70QJQ3wpuwI_hAl9ZYxIUVRw62I"
+      assert_equal url, "https://assets.imglab-cdn.net/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png&signature=78e-ysfcy3d0e0rj70QJQ3wpuwI_hAl9ZYxIUVRw62I"
     end
 
     it "returns url with path using a https url" do
@@ -723,7 +723,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png&signature=7Dp8Q01u_5YmpmH-j_y4P5vzOn_9EGvh77B3fi2Ke-s"
+      assert_equal url, "https://assets.imglab-cdn.net/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png&signature=7Dp8Q01u_5YmpmH-j_y4P5vzOn_9EGvh77B3fi2Ke-s"
     end
 
     it "returns url with path using a https url with reserved characters" do
@@ -736,7 +736,7 @@ describe Imglab do
           format: "png"
         )
 
-      assert_equal url, "https://cdn.imglab.io/assets/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png&signature=-zvh2hWXP8bHkoJVh8AdJFe9Kqdd1HpP1c2UmuQcYFQ"
+      assert_equal url, "https://assets.imglab-cdn.net/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png&signature=-zvh2hWXP8bHkoJVh8AdJFe9Kqdd1HpP1c2UmuQcYFQ"
     end
   end
 


### PR DESCRIPTION
* Change `Imglab::Source` default `host` to `imglab-cdn.net`.
* Change `Imglab::Source` default `subdomains` to `true`.
* Change `Imglab::Source` `secure?` instance method to `is_secure?`.
* Add new Ruby version 3.1 for CI testing.